### PR TITLE
0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
+- [Andrew Beeman](https://github.com/Kiendeleo)
 
 ### Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -144,7 +144,7 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 					url = "http://%s:%s/%s" % (address,port,t["rest"])
 					if t["type"] == "post":
 						r = requests.post(url, data=data, headers=headers)
-						self.mqtt_publish(t["topic"] + "/response", '{ "status" : %s, "response" : %s }' % (r.status_code, r.text))
+						self.mqtt_publish(t["topic"] + "/response", '{ "status" : %s, "response" : %s "data" : %s }' % (r.status_code, r.text, data))
 						if not t.get("disable_popup", False):
 							self._plugin_manager.send_plugin_message(self._identifier, dict(topic=t["topic"],message=message,command="Status code: %s" % r.status_code))
 					if t["type"] == "get":

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -122,8 +122,8 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 		# return ''.join(ls)
 		regex_opening_bracket = re.compile("{[^\d]", re.MULTILINE)
 		regex_closing_bracket = re.compile("[^\d]}", re.MULTILINE)
-		s = re.sub(regex_opening_bracket, "{{", s)
-		s = re.sub(regex_closing_bracket, "}}", s)
+		s = regex_opening_bracket.sub("{{", s)
+		s = regex_closing_bracket.sub("}}", s)
 		return s.format(*matches)
 
 	def _on_mqtt_subscription(self, topic, message, retained=None, qos=None, *args, **kwargs):

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -146,7 +146,11 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 						args = [json.dumps(octoprint.util.to_native_str(message))]
 					# substitute matches in command
 					data = self._substitute(t["command"], args)
-					url = "http://%s:%s/%s" % (address, port, t["rest"])
+					# substitute matches in REST API
+					if t["rest"].startswith("/"):
+						url = self._substitute("http://%s:%s%s" % (address, port, t["rest"]), args)
+					else:
+						url = self._substitute("http://%s:%s/%s" % (address, port, t["rest"]), args)
 					if t["type"] == "post":
 						r = requests.post(url, data=data, headers=headers)
 						self.mqtt_publish(t["topic"] + "/response", '{ "status" : %s, "response" : %s "data" : %s }' % (r.status_code, r.text, data))

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -121,10 +121,8 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 		# 			ls.append(c)
 		# return ''.join(ls)
 		if s.startswith("{"):
-			command_string = "{" + t["command"] + "}"
-		else:
-			command_string = t["command"]
-		return command_string.format(*matches)
+			s = "{" + s + "}"
+		return s.format(*matches)
 
 	def _on_mqtt_subscription(self, topic, message, retained=None, qos=None, *args, **kwargs):
 		self._logger.debug("Received from %s|%s" % (topic, message))

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -138,12 +138,12 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 					extract = t["extract"]
 					expr = jsonpath_rw.parse (extract if extract else '$')
 					# extract data from message
-					if message:
-						args = [match.value for match in expr.find (json.loads (message))]
+					if octoprint.util.to_native_str(message).startswith("{"):
+						args = [match.value for match in expr.find(json.loads(message))]
 					else:
-						args = []
+						args = [json.dumps(octoprint.util.to_native_str(message))]
 					# substitute matches in command
-					data = self._substitute (t["command"], args)
+					data = self._substitute(t["command"], args)
 					url = "http://%s:%s/%s" % (address, port, t["rest"])
 					if t["type"] == "post":
 						r = requests.post(url, data=data, headers=headers)

--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -120,8 +120,10 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 		# 		else:
 		# 			ls.append(c)
 		# return ''.join(ls)
-		if s.startswith("{"):
-			s = "{" + s + "}"
+		regex_opening_bracket = re.compile("{[^\d]", re.MULTILINE)
+		regex_closing_bracket = re.compile("[^\d]}", re.MULTILINE)
+		s = re.sub(regex_opening_bracket, "{{", s)
+		s = re.sub(regex_closing_bracket, "}}", s)
 		return s.format(*matches)
 
 	def _on_mqtt_subscription(self, topic, message, retained=None, qos=None, *args, **kwargs):

--- a/octoprint_mqttsubscribe/static/js/mqttsubscribe.js
+++ b/octoprint_mqttsubscribe/static/js/mqttsubscribe.js
@@ -25,7 +25,7 @@ $(function() {
 		}
 
 		self.onDataUpdaterPluginMessage = function(plugin, data) {
-			if (plugin != "mqttsubscribe") {
+			if (plugin !== "mqttsubscribe") {
 				return;
 			}
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_mqttsubscribe"
 plugin_name = "OctoPrint-MQTTSubscribe"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.4"
+plugin_version = "0.1.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* update REST API url to accept python format tokens from JSONPath Extraction
* fix issues with embedded objects in REST parameters
* support non-json message payload to topic, allows for open ended API commands like `api/printer/command` with REST parameter `{"command":{0}}` and sending the message connect or disconnect
* fix format replacement error
* switch to python format for command substitution