### PR TITLE
__init.py__: Adjust _subsitute() so it's not so fiddly with whitespace

### DIFF
--- a/octoprint_mqttsubscribe/__init__.py
+++ b/octoprint_mqttsubscribe/__init__.py
@@ -121,10 +121,9 @@ class MQTTSubscribePlugin(octoprint.plugin.SettingsPlugin,
 		# 		else:
 		# 			ls.append(c)
 		# return ''.join(ls)
-		regex_opening_bracket = re.compile("{[^\d]", re.MULTILINE)
-		regex_closing_bracket = re.compile("[^\d]}", re.MULTILINE)
-		s = regex_opening_bracket.sub("{{", s)
-		s = regex_closing_bracket.sub("}}", s)
+		s=s.replace("{", "{{").replace("}", "}}")
+		regex_double_bracket = re.compile("{{([\d]*)}}", re.MULTILINE)
+		s = regex_double_bracket.sub(r"{\1}", s)
 		return s.format(*matches)
 
 	def _on_mqtt_subscription(self, topic, message, retained=None, qos=None, *args, **kwargs):


### PR DESCRIPTION
The code originally wouldn't work correctly without a space before
and after the opening/closing curly brackets. This change allows the
code to work with or without them.

Signed-off-by: Nita Vesa <werecatf@outlook.com>